### PR TITLE
Added an option to block steam accounts that have not yet setup their profile. Also added config options to edit the kick messages players receive.

### DIFF
--- a/VPNShield/VPNShield.cs
+++ b/VPNShield/VPNShield.cs
@@ -38,15 +38,14 @@ namespace VPNShield
         public bool autoWhitelistUpdated = false;
         public bool autoBlacklistUpdated = false;
 
-		public string noPurchaseKick;
-		public string nonSetupKick;
-
 		private readonly string defaultConfig =
         "{\n" +
         "    \"block-vpns\": false,\n" +
         "    \"iphub-apikey\": \"put-key-here\",\n" +
         "    \"block-new-steam-accounts\": true,\n" +
-		"    \"block-non-setup-steam-accounts\": true,\n" +
+        "    \"block-non-setup-steam-accounts\": true,\n" +
+        "    \"no-purchases-kick-message\": \"This server does not allow new Steam accounts, you have to buy something on Steam before playing.\",\n" +
+        "    \"non-setup-kick-message\": \"This server does not allow non setup Steam accounts, you have to setup your Steam profile before playing.\",\n" +
 		"    \"verbose\": false,\n" +
         "}";
 
@@ -67,8 +66,6 @@ namespace VPNShield
             this.AddCommand("vs_disable", new DisableCommand(this));
             this.AddCommand("vs_whitelist", new WhitelistCommand(this));
 			this.AddConfig(new ConfigSetting("vs_global", true, true, "Whether or not to use the global config directory, default is true"));
-			this.AddConfig(new ConfigSetting("vs_no_purchases_message", "This server does not allow new Steam accounts, you have to buy something on Steam before playing.", true, "The message to display to players who are kicked for having a steam account without a purchased game."));
-			this.AddConfig(new ConfigSetting("vs_non_setup_message", "This server does not allow non setup Steam accounts, you have to setup your Steam profile before playing.", true, "The message to display to players who are kicked for having a Steam account that is not yet setup."));
 		}
 
         public override void OnEnable()
@@ -262,7 +259,7 @@ namespace VPNShield
 					if (config.Value<bool>("block-non-setup-steam-accounts"))
 					{
 						this.Info(ev.Player.Name + " has a non setup steam account.");
-						ev.Player.Ban(0, nonSetupKick);
+						ev.Player.Ban(0, config.Value<string>("non-setup-kick-message"));
 						return true;
 					}
 					else
@@ -278,7 +275,7 @@ namespace VPNShield
                     this.Info(ev.Player.Name + " has a new steam account with no purchases.");
                     if (config.Value<bool>("block-new-steam-accounts"))
                     {
-                        ev.Player.Ban(0, noPurchaseKick);
+                        ev.Player.Ban(0, config.Value<string>("no-purchases-kick-message"));
                         return true;
                     }
                 }
@@ -549,9 +546,6 @@ namespace VPNShield
                 plugin.SaveAutoBlacklistToFile();
                 plugin.autoBlacklistUpdated = false;
             }
-
-			plugin.noPurchaseKick = plugin.GetConfigString("vs_no_purchases_message");
-			plugin.nonSetupKick = plugin.GetConfigString("vs_non_setup_message");
 		}
     }
 

--- a/VPNShield/VPNShield.cs
+++ b/VPNShield/VPNShield.cs
@@ -73,6 +73,7 @@ namespace VPNShield
             try
             {
                 SetUpFileSystem();
+				ValidateConfig();
                 this.Info("Loading config: " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json...");
                 config = JObject.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json"));
                 this.Info("Loaded config.");
@@ -81,8 +82,8 @@ namespace VPNShield
                 autoBlacklist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-blacklist.json")).Values<string>());
                 whitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/whitelist.json")).Values<string>());
                 this.Info("Loaded data files.");
-            }
-            catch (Exception e)
+			}
+			catch (Exception e)
             {
                 this.Error("Could not load config: " + e.ToString());
             }
@@ -115,6 +116,23 @@ namespace VPNShield
                 File.WriteAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/whitelist.json", defaultlist);
             }
         }
+
+		public void ValidateConfig()
+		{
+			List<string> lines = File.ReadAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json").ToList();
+			string[] configEntries = defaultConfig.Split(Environment.NewLine.ToCharArray());
+			for (int i = 1; i < configEntries.Length - 1; i++)
+			{
+				string[] split = configEntries[i].Split(':');
+				string configKey = split[0];
+				string configValue = split[1];
+				if (!lines.Select(x => x.Split(':')[0]).Contains(configKey))
+				{
+					lines.Insert(i, $"{configKey}:{configValue}");
+				}
+			}
+			File.WriteAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json", lines);
+		}
 
         public void SaveWhitelistToFile()
         {

--- a/VPNShield/VPNShield.cs
+++ b/VPNShield/VPNShield.cs
@@ -73,7 +73,7 @@ namespace VPNShield
             try
             {
                 SetUpFileSystem();
-				ValidateConfig();
+                ValidateConfig();
                 this.Info("Loading config: " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json...");
                 config = JObject.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json"));
                 this.Info("Loaded config.");
@@ -82,8 +82,8 @@ namespace VPNShield
                 autoBlacklist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-blacklist.json")).Values<string>());
                 whitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/whitelist.json")).Values<string>());
                 this.Info("Loaded data files.");
-			}
-			catch (Exception e)
+            }
+            catch (Exception e)
             {
                 this.Error("Could not load config: " + e.ToString());
             }
@@ -117,22 +117,22 @@ namespace VPNShield
             }
         }
 
-		public void ValidateConfig()
-		{
-			List<string> lines = File.ReadAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json").ToList();
-			string[] configEntries = defaultConfig.Split(Environment.NewLine.ToCharArray());
-			for (int i = 1; i < configEntries.Length - 1; i++)
-			{
-				string[] split = configEntries[i].Split(':');
-				string configKey = split[0];
-				string configValue = split[1];
-				if (!lines.Select(x => x.Split(':')[0]).Contains(configKey))
-				{
-					lines.Insert(i, $"{configKey}:{configValue}");
-				}
-			}
-			File.WriteAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json", lines);
-		}
+        public void ValidateConfig()
+        {
+            List<string> lines = File.ReadAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json").ToList();
+            string[] configEntries = defaultConfig.Split(Environment.NewLine.ToCharArray());
+            for (int i = 1; i < configEntries.Length - 1; i++)
+            {
+                string[] split = configEntries[i].Split(':');
+                string configKey = split[0];
+                string configValue = split[1];
+                if (!lines.Select(x => x.Split(':')[0]).Contains(configKey))
+                {
+                    lines.Insert(i, $"{configKey}:{configValue}");
+                }
+            }
+            File.WriteAllLines(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json", lines);
+        }
 
         public void SaveWhitelistToFile()
         {

--- a/VPNShield/VPNShield.cs
+++ b/VPNShield/VPNShield.cs
@@ -38,7 +38,7 @@ namespace VPNShield
         public bool autoWhitelistUpdated = false;
         public bool autoBlacklistUpdated = false;
 
-		private readonly string defaultConfig =
+        private readonly string defaultConfig =
         "{\n" +
         "    \"block-vpns\": false,\n" +
         "    \"iphub-apikey\": \"put-key-here\",\n" +
@@ -46,7 +46,7 @@ namespace VPNShield
         "    \"block-non-setup-steam-accounts\": true,\n" +
         "    \"no-purchases-kick-message\": \"This server does not allow new Steam accounts, you have to buy something on Steam before playing.\",\n" +
         "    \"non-setup-kick-message\": \"This server does not allow non setup Steam accounts, you have to setup your Steam profile before playing.\",\n" +
-		"    \"verbose\": false,\n" +
+        "    \"verbose\": false,\n" +
         "}";
 
         private readonly string defaultlist =
@@ -65,27 +65,27 @@ namespace VPNShield
             this.AddCommand("vs_enable", new EnableCommand(this));
             this.AddCommand("vs_disable", new DisableCommand(this));
             this.AddCommand("vs_whitelist", new WhitelistCommand(this));
-			this.AddConfig(new ConfigSetting("vs_global", true, true, "Whether or not to use the global config directory, default is true"));
-		}
+            this.AddConfig(new ConfigSetting("vs_global", true, true, "Whether or not to use the global config directory, default is true"));
+        }
 
         public override void OnEnable()
         {
-			try
-			{
-				SetUpFileSystem();
-				this.Info("Loading config: " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json...");
-				config = JObject.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json"));
-				this.Info("Loaded config.");
-				this.Info("Loading data files from " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/...");
-				autoWhitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-whitelist.json")).Values<string>());
-				autoBlacklist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-blacklist.json")).Values<string>());
-				whitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/whitelist.json")).Values<string>());
-				this.Info("Loaded data files.");
-			}
-			catch (Exception e)
-			{
-				this.Error("Could not load config: " + e.ToString());
-			}
+            try
+            {
+                SetUpFileSystem();
+                this.Info("Loading config: " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json...");
+                config = JObject.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/config.json"));
+                this.Info("Loaded config.");
+                this.Info("Loading data files from " + FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/...");
+                autoWhitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-whitelist.json")).Values<string>());
+                autoBlacklist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/auto-blacklist.json")).Values<string>());
+                whitelist = new HashSet<string>(JArray.Parse(File.ReadAllText(FileManager.GetAppFolder(GetConfigBool("vs_global")) + "VPNShield/whitelist.json")).Values<string>());
+                this.Info("Loaded data files.");
+            }
+            catch (Exception e)
+            {
+                this.Error("Could not load config: " + e.ToString());
+            }
         }
 
         public void SetUpFileSystem()
@@ -256,17 +256,17 @@ namespace VPNShield
 
                 if (foundStrings.Length == 0)
                 {
-					if (config.Value<bool>("block-non-setup-steam-accounts"))
-					{
-						this.Info(ev.Player.Name + " has a non setup steam account.");
-						ev.Player.Ban(0, config.Value<string>("non-setup-kick-message"));
-						return true;
-					}
-					else
-					{
-						this.Error("Steam account check failed. Their profile did not have the required information.");
-						return false;
-					}
+                    if (config.Value<bool>("block-non-setup-steam-accounts"))
+                    {
+                        this.Info(ev.Player.Name + " has a non setup steam account.");
+                        ev.Player.Ban(0, config.Value<string>("non-setup-kick-message"));
+                        return true;
+                    }
+                    else
+                    {
+                        this.Error("Steam account check failed. Their profile did not have the required information.");
+                        return false;
+                    }
                 }
 
                 bool isLimitedAccount = foundStrings[0].Where(c => char.IsDigit(c)).ToArray()[0] != '0';
@@ -546,7 +546,7 @@ namespace VPNShield
                 plugin.SaveAutoBlacklistToFile();
                 plugin.autoBlacklistUpdated = false;
             }
-		}
+        }
     }
 
     internal class CheckPlayer : IEventHandlerPlayerJoin


### PR DESCRIPTION
Added in config.json
- `"block-non-setup-steam-accounts"` - Bool that can be set in the config just like any other config option. Blocks steam accounts that have not yet been setup.

Added in SCP config
- `vs_no_purchases_message` - Determines the message to be displayed to a user when they are kicked for not having any purchases on their account.
- `vs_non_setup_message` - Determines the message to be displayed to a user when they are kicked for not having their steam profile setup.

EDIT: Added a config validator. This should automatically insert all new configs into existing users' config files.

Bumped version number `3.2.0` -> `3.3.0`